### PR TITLE
Sign in is complete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ runtime errors.  It can be useful, but not as useful as the "background page" de
 
 
 
-<!-- https://docs.google.com/drawings/d/1C32qtyMrsqAZXxN7TEG3lryZXn56owVHnZhwxoAAOLo/edit?usp=sharing ->
+<!-- https://docs.google.com/drawings/d/1C32qtyMrsqAZXxN7TEG3lryZXn56owVHnZhwxoAAOLo/edit?usp=sharing -->

--- a/backgroundWeVoteAPICalls.js
+++ b/backgroundWeVoteAPICalls.js
@@ -39,7 +39,7 @@ function getOrganizationFound (locationHref, sendResponse) {
   let data = {};
   const hrefEncoded = encodeURIComponent(locationHref);
   const apiURL = `${rootApiURL}/voterGuidePossibilityRetrieve/?voter_device_id=${localStorage['voterDeviceId']}&url_to_scan=${hrefEncoded}`;
-  console.log("STEVE STEVE voterGuidePossibilityRetrieve apiURL: " + apiURL);
+  console.log("voterGuidePossibilityRetrieve apiURL: " + apiURL);
   $.getJSON(apiURL, '', (res) => {
     console.log("voterGuidePossibilityRetrieve API results", res);
     if (res && res.organization) {
@@ -50,7 +50,7 @@ function getOrganizationFound (locationHref, sendResponse) {
       } = res.organization;
       const {voter_guide_possibility_edit: possibilityUrl, voter_guide_possibility_id: possibilityId} = res;
 
-      console.log("STEVE STEVE voter_guide_possibility_id:", possibilityId);
+      console.log("voter_guide_possibility_id:", possibilityId);
 
       data = {
         email: email,
@@ -73,20 +73,41 @@ function getOrganizationFound (locationHref, sendResponse) {
   return data;
 }
 
-function updateSignedInVoter() {
+function getVoterSignInInfo (sendResponse) {
+  let data = {};
   let voterDeviceId = localStorage['voterDeviceId'];
+  const apiURL = `${rootApiURL}/voterRetrieve/?voter_device_id=${voterDeviceId}`;
+  console.log("getVoterSignInInfo apiURL: " + apiURL);
+
   if (voterDeviceId && voterDeviceId.length > 0) {
-    const apiURL = `${rootApiURL}/voterRetrieve/?voter_device_id=${voterDeviceId}`;
-    console.log("STEVE voterRetrieve: " + apiURL);
     $.getJSON(apiURL, '', (res) => {
-      console.log("get json from updateSignedInVoter API SUCCESS", res);
-      const {full_name: fullName, we_vote_id: weVoteId, voter_photo_url_medium: photoURL } = res;
-      window.voterName = fullName;
-      window.voterPhotoURL = photoURL;
-      window.voterWeVoteId = weVoteId;
+      console.log("get json from getVoterSignInInfo voterRetrieve API SUCCESS", res);
+      const {success, full_name: fullName, we_vote_id: weVoteId, voter_photo_url_medium: photoURL } = res;
+      data = {
+        success:  success,
+        error:    success ? '' : res.status,
+        fullName: fullName,
+        photoURL: photoURL,
+        weVoteId: weVoteId,
+      };
+      // console.log("get json from updateSignedInVoter photoURL" + photoURL);
+      sendResponse({data: data});
     }).fail((err) => {
-      console.log('updateSignedInVoter error', err);
+      data = {
+        success: false,
+        error: "EXCEPTION",
+        err: err,
+      };
+      console.log('getVoterSignInInfo error', err);
+      sendResponse({data: data});
     });
+  } else {
+    console.log("NOT SIGNED IN ERROR in getVoterSignInInfo no voterDeviceId in local storage");
+    data = {
+      success: false,
+      error: "NOVOTERID",
+    };
+    sendResponse({data: data});
   }
 }
 
@@ -95,7 +116,7 @@ function getPossiblePositions(possibilityId, sendResponse) {
   let voterDeviceId = localStorage['voterDeviceId'];
   if (voterDeviceId && voterDeviceId.length > 0) {
     const apiURL = `${rootApiURL}/voterGuidePossibilityPositionsRetrieve/?voter_device_id=${voterDeviceId}&voter_guide_possibility_id=${possibilityId}`;
-    console.log("STEVE getPossiblePositions: " + apiURL);
+    console.log("getPossiblePositions: " + apiURL);
     $.getJSON(apiURL, '', (res) => {
       console.log("get json from getPossiblePositions API SUCCESS", res);
 

--- a/extWordHighlighter.js
+++ b/extWordHighlighter.js
@@ -289,13 +289,14 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
   console.log("Steve chrome.contextMenus.onClicked: ");
 
   // There is no DOM to attach to here
+  // TODO: This is the wrong way to do this, the content script should send a message, and wait for a WeVote API response
   chrome.tabs.sendMessage(tab.id, {
     command: "openWeDialog",
   }, function(result) {
     console.log( "on click openWeDialog ", result);
-    let p1= new Promise((resolve, reject) => {
-      updateSignedInVoter();
-    });
+    // let p1= new Promise((resolve, reject) => {
+    //   updateSignedInVoter();
+    // });
   });
 
 
@@ -382,8 +383,7 @@ chrome.runtime.onMessage.addListener(
         storedDeviceId: localStorage['voterDeviceId'],  // Outgoing voterDeviceId for viewing all other pages
       });
     } else if(request.command==="getVoterInfo") {
-      const {voterName, voterPhotoURL, voterWeVoteId, voterEmail} = window;
-      sendResponse({ voterName, voterPhotoURL, voterWeVoteId, voterEmail });
+      getVoterSignInInfo (sendResponse);
     } else if(request.command==="addGroup") {
       sendResponse({success:addGroup(request.group, request.color, request.fcolor, request.findwords, request.showon, request.dontshowon, request.words, request.groupType, request.remoteConfig, request.regex, request.showInEditableFields)});
     } else if(request.command==="deleteGroup") {

--- a/hilitor.js
+++ b/hilitor.js
@@ -1,9 +1,14 @@
 // Original JavaScript code by Chirp Internet: www.chirp.com.au
 // Please acknowledge use of this code by including this header.
 
-// modified to : 
+// modified to :
 //  - accept an array of words, phrases
 //  - return the amount of matches found
+
+// modified by WeVote to:
+//  - stop the recursive search for words at the id weContainer (our menus)
+//  - stop at the id weTrash (the original dom, that becomes dormant and invisible, with a fresh copy in the new iframe)
+
 
 function Hilitor(id, tag) {
 
@@ -121,8 +126,16 @@ function Hilitor(id, tag) {
 
     if (node == undefined || !node) {return;}
     if (!matchRegex) {return;}
-    if (skipTags.test(node.nodeName)||skipClasses.test(node.className)) {return;}
 
+    // Begin modification for WeVote
+    // Before change this was...  if (skipTags.test(node.nodeName)||skipClasses.test(node.className)) {return;}
+    if (skipTags.test(node.nodeName) ||
+        skipClasses.test(node.className) ||
+        node.id === "weTrash" ||
+        node.id === "weContainer") {
+      return;
+    }
+    // End of modification for WeVote
 
     if (node.hasChildNodes()) {
       for (var i = 0; i < node.childNodes.length; i++) {

--- a/popup.js
+++ b/popup.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function () {
     return false;
   });
 
-  // STEVE STEVE STEVE
+  // STEVE STEVE STEVE TODO: This was a valuable experiment, but I don't think we need this -- if there is no id, they need to go to wevote.us to get one, and get it through the contentWeVote path.
   document.getElementById("loginTest").addEventListener('click', function () {
     let voterDeviceId = localStorage['voterDeviceId'];
     //const weVoteServerApiRootUrl = 'http://localhost:8000/apis/v1';  // 'https://api.wevoteusa.org/apis/v1';
@@ -76,24 +76,6 @@ document.addEventListener('DOMContentLoaded', function () {
         console.log('error getting new voterDeviceId', err);
       });
     }
-
-    // // test 3c
-    //
-    // getAccessToken(() => {
-    //   console.log('oauth2_access_token received');
-    // });
-
-    // // Do first step of twitter oAuth
-    // const requestOauth1URL = `${weVoteServerApiRootUrl}/twitterSignInStart` +
-    //   `?cordova=true&voter_device_id=${voterDeviceId}&return_url=http://nonsense.com`;
-    //
-    // window.$.get(requestOauth1URL, '', (res) => {
-    //   console.log("get html from test wevote oauth1", res);
-    //
-    // }).fail((err) => {
-    //   console.log('error', err);
-    // });
-
     return false;
   });
 

--- a/tabWordHighlighter.js
+++ b/tabWordHighlighter.js
@@ -186,7 +186,6 @@ chrome.runtime.sendMessage({command: "getStatus"}, function (response) {
       //start the highlight loop
       highlightLoop();
     });
-
   }
 });
 

--- a/weVote.css
+++ b/weVote.css
@@ -141,6 +141,15 @@
   width: 100px;
 }
 
+.selectedInfo {
+  background-color: #888888;
+  color: white;
+  position: relative;
+  left: 2px;
+  top: -2px;
+  width: 100px;
+}
+
 .deselected {
   background-color: white;
   color: #235470;


### PR DESCRIPTION
New sign in modal dialog explaining how to authenticate if no device_id
in the localStorage, or the device_id is outdated.
Recursive scan for highlights no longer scans our menus (weContainer) or
the saved off and hidden original DOM from before the menus were opened.
Organization email now displayed on the top menu.
SVGs for the Endorse/Opposed buttons styling improved.