### PR TITLE
Checkin that covers "version": "0.0.0.18"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ May 2020: The boiler plate needed for the "new chrome store website", you will h
 And at the very bottom of the page, press the `Publish changes` button.  And press `Ok` on the confirm dialog.  The you
 will see a dialog that says something like "Your item is in the process of being published and may take up to 60 minutes to appear in the Chrome Web Store." -- Then you are done.
 
+### Note May 2020
+
+**Do not release a new version from the new console, it makes a compeletely new chrome store entry with a new id, 
+which will not match **
+            if (sender.id === 'pmpmiggdjnjhdlhgpfcafbkghhcjocai' ||
+                sender.id === 'lfifjogjdncflocpmhfhhlflgndgkjdo' ||
+                sender.id === 'eofojjpbgfdogalmibgljcgdipkhoclc' ||
+                sender.id === 'highlightthis@deboel.eu') {
+
+**And therefore will not work (the chrome store auto-releases new versions) also since it has a new ID, the installed base
+will not receive the updates automatically.
+
+On the [Chrome Store Dev Console](https://chrome.google.com/u/2/webstore/devconsole/a50353be-1bec-4452-b8e4-c5fd9f2f6336/eofojjpbgfdogalmibgljcgdipkhoclc/edit/package?hl=en)
+go to the **Package** tab on the left side menu, to replace the current release.
+
 
 ## Testing: Deleting an possibility that was made from the left pane
 Voter Guide endorsements can be in the "Possibilities" state (Recommended by a voter or a WeVote power volunteer), or "Stored"

--- a/manifest.json
+++ b/manifest.json
@@ -40,5 +40,5 @@
    "permissions": [ "tabs", "contextMenus", "activeTab" ],
    "short_name": "We Vote Chrome Extension",
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "0.0.0.15"
+   "version": "0.0.0.18"
 }

--- a/tabWordHighlighter.js
+++ b/tabWordHighlighter.js
@@ -101,6 +101,8 @@ $(() => {
         debug && console.log('onMessage.addListener() in tabWordHighlighter got a message: ' + request.command);
 
         if (sender.id === 'pmpmiggdjnjhdlhgpfcafbkghhcjocai' ||
+            sender.id === 'lfifjogjdncflocpmhfhhlflgndgkjdo' ||
+            sender.id === 'eofojjpbgfdogalmibgljcgdipkhoclc' ||
             sender.id === 'highlightthis@deboel.eu') {
 
           if (request.command === 'displayHighlightsForTabAndPossiblyEditPanes') {


### PR DESCRIPTION
No functional difference between 0.0.0.15, and 0.0.0.18, just a few failed attempts at uploading the
zip file to the the correct place in the Chrome Store, with the need for a new version number on each attempt..  This Pr does have a new chrome extensionid encoded into tabWordHighlighter.js