### PR TITLE
WV-303: Fix icon alignment in edit panel. 

### DIFF
--- a/css/weVoteGrid.css
+++ b/css/weVoteGrid.css
@@ -93,7 +93,7 @@
 .thumbIconSVG {
   height:22px;
   width: 22px;
-  transform: translate(-2px, -3px);
+  transform: translate(-2px, -1px);
 }
 .thumbIconSVGContent {
   height:22px;
@@ -108,7 +108,7 @@
 
 .commentIconSVG {
   height: 18px;
-  transform: translate(23px, -43px);
+  transform: translate(23px, -38px);
 }
 
 .commentOnly {

--- a/js/contentForeground/contentWeVoteUI.js
+++ b/js/contentForeground/contentWeVoteUI.js
@@ -911,7 +911,7 @@ function unfurlableGrid (index, name, photo, party, office, description, inLeftP
     }
     if (showBar) {
       iconContainer +=
-        '  <div style="transform: translate(19px, -26px); color: white; font-size: 10pt; background-color:' + backgroundColor(stance, isStored) + '; width: 2px;">&#124;</div>';
+        '  <div style="transform: translate(19px, -19px); color: white; font-size: 10pt; background-color:' + backgroundColor(stance, isStored) + '; width: 2px;">&#124;</div>';
     }
     if (showComment) {    // https://material.io/resources/icons/?style=baseline comment
       iconContainer +=


### PR DESCRIPTION
Move thumb icon down; Comment icon down and to the left; Separator line between them down.