### PR TITLE
WV-319, Many pages I am browsing get added as Voter Guide Possibilities.

### DIFF
--- a/js/serviceWorker/extWordHighlighter.js
+++ b/js/serviceWorker/extWordHighlighter.js
@@ -606,15 +606,20 @@ chrome.runtime.onMessage.addListener(
       getOrganizationFound(request.url, sendResponse);
     } else if (request.command === 'getHighlights') {
       // Highlight the captured positions
+      console.log('request.command:', request.command);
       showVoterGuideHighlights = true;
       showCandidateOptionsHighlights = false;
       getHighlightsListsFromApiServer(request.url, request.voterDeviceId, request.tabId, request.doReHighlight, sendResponse, showVoterGuideHighlights, showCandidateOptionsHighlights,request.pageContent);
-    } else if (request.command === 'getCombinedHighlights') {
-      // Highlight the captured positions AND the recognized candidate names
-      showVoterGuideHighlights = true;
-      showCandidateOptionsHighlights = true;
-      getHighlightsListsFromApiServer(request.url, request.voterDeviceId, request.tabId, request.doReHighlight, sendResponse, showVoterGuideHighlights, showCandidateOptionsHighlights,request.pageContent);
-    } else if (request.command === 'getPositions') {
+    }
+    // This action commented out as a fix for the defect WV-319
+    // else if (request.command === 'getCombinedHighlights') {
+    //   // Highlight the captured positions AND the recognized candidate names
+    //   console.log('request.command:', request.command);
+    //   showVoterGuideHighlights = true;
+    //   showCandidateOptionsHighlights = true;
+    //   getHighlightsListsFromApiServer(request.url, request.voterDeviceId, request.tabId, request.doReHighlight, sendResponse, showVoterGuideHighlights, showCandidateOptionsHighlights,request.pageContent);
+    // }
+    else if (request.command === 'getPositions') {
       console.log('getPositions received with request ', request);
       getPossiblePositions(request.voterGuidePossibilityId, request.hrefURL, request.voterDeviceId, request.isIFrame, sendResponse);
     } else if (request.command === 'savePosition') {


### PR DESCRIPTION
Removing the action that happens when the request.command received from a tab equals 'getCombinedHighlights' prevents the extension from adding a Voter Guide Possibility unless a button on the extension Popup is clicked.