### PR TITLE
Fix- mutation observer as part of WV-439

### DIFF
--- a/js/common/globalState.js
+++ b/js/common/globalState.js
@@ -49,6 +49,7 @@ const initialState = {
   voterWeVoteId: '',
   weVoteId: '',
   windowId: 0,
+  firstTimePanelOpen: false
 };
 
 async function getGlobalState () {

--- a/js/contentForeground/tabWordHighlighter.js
+++ b/js/contentForeground/tabWordHighlighter.js
@@ -35,7 +35,6 @@ let printHighlights = true;
 let uniqueNameMatches = [];
 let voterDeviceId = '';
 let debug = false;
-let firstTimePanelOpen = true;
 
 document.addEventListener('DOMContentLoaded', async function () {  // This wastes about 1 ms for every open tab in the browser, that we are not going to highlight on
   const t0 = performance.now();
@@ -80,7 +79,7 @@ document.addEventListener('DOMContentLoaded', async function () {  // This waste
     for (const entry of entries) {
       if (entry.type== 'childList' && entry.addedNodes.length >1){
         let state = await getGlobalState();
-        let { showHighlights, showPanels, tabId} = state;
+        let { showHighlights, showPanels, tabId, firstTimePanelOpen} = state;
 
         if (showPanels){
           if(firstTimePanelOpen){
@@ -96,6 +95,7 @@ document.addEventListener('DOMContentLoaded', async function () {  // This waste
               }, 5000);
             }
             firstTimePanelOpen = false;
+            await updateGlobalState({ firstTimePanelOpen: firstTimePanelOpen});
           }else {
             showPanels = false;
             displayHighlightingAndPossiblyEditor(showHighlights, showPanels, tabId);

--- a/js/popup/popup.js
+++ b/js/popup/popup.js
@@ -322,6 +322,13 @@ document.addEventListener('DOMContentLoaded', function () {
         let showPanels = !state.showPanels;
         let showHighlights = showPanels; // Assuming that showing panels implies highlighting
         const isFromPDF = pdfURL && pdfURL.endsWith('.pdf');
+        let firstTimePanelOpen = state.firstTimePanelOpen
+
+        if (openEditPanelButtonSelector.text() === openEditText){
+          firstTimePanelOpen = true
+        }else if(openEditPanelButtonSelector.text() === removeEditText){
+          firstTimePanelOpen = false
+        }
 
         await registerPromise(
           updateGlobalState({
@@ -330,6 +337,7 @@ document.addEventListener('DOMContentLoaded', function () {
             showPanels: showPanels,
             showHighlights: showHighlights,
             tabId: showPanels ? tabId : -1, // Use -1 as tabId to indicate removal
+            firstTimePanelOpen: firstTimePanelOpen
           })
         );
 


### PR DESCRIPTION
globalState.js -  included a variable 'firstTimePanelOpen' , which helps identifying the side panel option was selected, so that the targetNode in the mutation observer can observe changes in the iframe instead of the whole document.

tabWordHighlighter.js - Added code to read the firstTimePanelOpen variable from globalstate

popup.js - Setting the value for firstTimePanelOpen  based on the option that was selected.